### PR TITLE
Massive rewrite/new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,25 @@ Name | Mandatory | Type | Description
 
   @Type(java.lang.Runnable.class, functional=true)
 
+  @Type(other.lib.someClass.class, declare=false)
+
 })
 package org.mypackage;
 ```
+
+### plugin options 
+
+to set at Gradle/maven configuration
+
+Name | default | Description
+--- | --- | --- | ---
+**ts.outfile** | "out" | out TS filename 
+**ts.registry** | "JavaTypeRegistry" | name of type registry interface (choose unique name per project) 
+**compatibility** | "NASHORN" | JS engine : "NASHORN" (deprecated), "RHINO" or "GRAALJS"
+**ts.scan** | _(none)_ | directories and/or jars to scan public types to declare, separated by the path separator.
+**ts.scan.include** | _(none)_ | comma separated binary name prefixes; only matching classes are scanned
+**ts.scan.exclude** | _(none)_ | comma separated binary name prefixes to skip, applied after `ts.scan.include`
+
 
 ### Add the dependency containing the Java2TS Processor
 
@@ -193,6 +209,92 @@ package org.mypackage;
     </execution>
   </executions>
 </plugin>
+```
+
+### gradle 
+
+example of gradle build generating types for all public classes of the project.
+
+put this file at `src/apiTypes/java/package-info.java`
+
+```java
+@Java2TS(
+        declare = {
+            @Type(value = java.nio.file.Files.class, export = true),
+            @Type(value = java.nio.file.Path.class),
+            @Type(value = java.nio.file.Paths.class, export = true),
+            @Type(value = java.util.Arrays.class, export = true),
+            @Type(value = java.net.URI.class, export = true)
+        })
+package org.zaproxy.zap.api;
+
+import org.bsc.processor.annotation.Java2TS;
+import org.bsc.processor.annotation.Type;
+```
+
+then in your gradle.kts:
+
+```kotlin
+// local install only
+//val java2tsHome = rootDir.parentFile.resolve("java2typescript")
+//val java2tsJars =
+//    files(
+//        java2tsHome.resolve("core/target/java2ts-processor-core-2.0-20241009.jar"),
+//        java2tsHome.resolve("processor/target/java2ts-processor-2.0-20241009.jar"),
+//    )
+
+val typesProcessor: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+
+// in your dependecies block
+dependencies {
+  ...
+  typesProcessor("org.bsc.processor:java2ts-processor:2.0")
+  // local install
+  // typesProcessor(java2tsJars)
+}
+
+// GraalJS API TypeScript declaration generation
+val apiTypesOutputDir = layout.buildDirectory.dir("generated/api-types")
+
+tasks.register<JavaCompile>("generateApiTypes") {
+    group = "build"
+    description = "Generates TypeScript declarations for the GraalJS API."
+
+    val main = sourceSets["main"]
+    dependsOn(tasks.named("classes"))
+    source = fileTree("src/apiTypes/java")
+
+    val resolveClasspath = files(main.output, main.runtimeClasspath, typesProcessor)
+    classpath = resolveClasspath
+    options.annotationProcessorPath = resolveClasspath
+
+    val scanRoots = main.output.classesDirs
+    inputs.files(scanRoots).withPropertyName("YOURPROJECTNAMEClasses")
+
+    options.generatedSourceOutputDirectory.set(apiTypesOutputDir)
+    // Nothing is actually compiled to .class with -proc:only, but JavaCompile still needs a target.
+    destinationDirectory.set(layout.buildDirectory.dir("classes/api-types"))
+
+    doFirst {
+        options.compilerArgs =
+            listOf(
+                "-proc:only",
+                "-processor",
+                "org.bsc.processor.TypescriptProcessor",
+                "-Ats.outfile=YOURPROJECT-api",
+                "-Ats.registry=YOURPROJECTApi",
+                "-Ats.scan=" + scanRoots.joinToString(File.pathSeparator),
+                // Suppress all lint (deprecation/removal/processing/...) and do not fail on it.
+                "-Xlint:none",
+                "-nowarn",
+            )
+    }
+}
+
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Name | Mandatory | Type | Description
 **alias** | No | String | Assign a new name to exported class in typescript
 **export** | No | boolean | If **true**, other than typescript declaration adds definition in file *`-types.ts`. **It is need for instantiable classes, in order  to use `new` operator or factory method(s)**
 **functional** | No | boolean | If **true** other than typescript declaration adds a **particular** definition. Valid only for interfaces that have one abstract method and haven't `@FunctionalInterface` annotation
+**declare** | No | boolean | If **false**, does not export the class to the typescript file, but use it for inheritance "extends" optimization. (ex: not declaring library types already exported in another TS file)
 
 **Example**
 ```Java

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Name | default | Description
 **ts.outfile** | "out" | out TS filename 
 **ts.registry** | "JavaTypeRegistry" | name of type registry interface (choose unique name per project) 
 **compatibility** | "NASHORN" | JS engine : "NASHORN" (deprecated), "RHINO" or "GRAALJS"
+**ignoreDeprecated** | "false" | do not declare `@Deprecated` elements.
 **ts.scan** | _(none)_ | directories and/or jars to scan public types to declare, separated by the path separator.
 **ts.scan.include** | _(none)_ | comma separated binary name prefixes; only matching classes are scanned
 **ts.scan.exclude** | _(none)_ | comma separated binary name prefixes to skip, applied after `ts.scan.include`

--- a/core/src/main/java/org/bsc/java2typescript/ClasspathScanner.java
+++ b/core/src/main/java/org/bsc/java2typescript/ClasspathScanner.java
@@ -53,8 +53,8 @@ public final class ClasspathScanner {
 
     /**
      * Outcome of a scan: the types to declare, plus the names that were rejected because they could
-     * not be loaded. The skipped names are reported rather than swallowed — a class missing from the
-     * processor classpath is usually a build misconfiguration worth seeing.
+     * not be loaded or introspected. The skipped names are kept rather than swallowed — a class
+     * missing from the processor classpath is usually a build misconfiguration worth seeing.
      */
     public static final class Result {
 
@@ -145,12 +145,15 @@ public final class ClasspathScanner {
                 try {
                     final Class<?> type = TSType.loadClass(binaryName);
                     if (isPublicApiType(type) && type.getPackage() != null) {
+                        // Loading succeeds lazily: a class whose method signatures reference absent
+                        // types only fails when its members are read, which would otherwise happen
+                        // deep inside a transformer and abort the whole run.
+                        checkIntrospectable(type);
                         found.put(binaryName, TSType.of(type));
                     }
                 } catch (Throwable t) {
-                    // A class whose supertype or a referenced type is absent cannot be introspected
-                    // by the transformers either, so skipping it here is the same outcome, reported
-                    // earlier and with a name attached.
+                    // Not declarable: reported with a name attached rather than swallowed, since a
+                    // root missing from the processor classpath shows up here first.
                     skipped.add(String.format("%s (%s)", binaryName, t));
                 }
             }
@@ -218,6 +221,26 @@ public final class ClasspathScanner {
             return false;
         }
         return excludes.stream().noneMatch(binaryName::startsWith);
+    }
+
+    /**
+     * Force resolution of everything a declaration needs to read, so that a type referencing an
+     * absent class is rejected up front instead of throwing from inside a transformer.
+     * <p>
+     * Class loading resolves references lazily: {@link Class#forName(String, boolean, ClassLoader)}
+     * happily returns a class whose method signatures name types that are nowhere on the classpath,
+     * and only reading those members raises {@link NoClassDefFoundError}. Optional dependencies make
+     * this routine — a UI class referencing JavaFX, a driver referencing a browser library.
+     *
+     * @param type the class to probe
+     */
+    public static void checkIntrospectable(Class<?> type) {
+        type.getMethods();
+        type.getDeclaredMethods();
+        type.getFields();
+        type.getConstructors();
+        type.getInterfaces();
+        type.getSuperclass();
     }
 
     /**

--- a/core/src/main/java/org/bsc/java2typescript/ClasspathScanner.java
+++ b/core/src/main/java/org/bsc/java2typescript/ClasspathScanner.java
@@ -1,0 +1,244 @@
+package org.bsc.java2typescript;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Enumerates the types to declare by scanning compiled class files, instead of listing them one by
+ * one in {@code @Java2TS(declare = {@Type(...)})}.
+ * <p>
+ * This exists because listing an entire API surface by hand does not scale: a project with hundreds
+ * of public types would need a generated source file just to carry the annotation. Scanning moves
+ * that enumeration into the processor, where the classes are already reachable.
+ * <p>
+ * <b>Classpath requirement.</b> Scanning only decides <em>which</em> names to declare; the classes
+ * themselves are loaded through {@link TSType}'s class loader, i.e. the annotation processor
+ * classpath. Every scanned root (and the transitive dependencies of the classes in it) must
+ * therefore also be on {@code -processorpath}, otherwise the class is unloadable and skipped.
+ * <p>
+ * <b>Selection rule.</b> A type is included when it is public, non-synthetic, in a named package,
+ * and — for nested types — every enclosing type is public too. A public class nested inside a
+ * package-private one is not referenceable from outside, so it is not part of the API surface.
+ * Anonymous and local classes are excluded, as are classes in the default package (they have no
+ * namespace to be declared in).
+ *
+ * @see TSType#loadClass(String)
+ */
+public final class ClasspathScanner {
+
+    /** Roots to scan: directories and/or jars, separated by the platform path separator. */
+    public static final String OPTION_SCAN = "ts.scan";
+    /** Comma-separated binary-name prefixes; when set, only matching classes are scanned. */
+    public static final String OPTION_INCLUDE = "ts.scan.include";
+    /** Comma-separated binary-name prefixes to skip; applied after {@link #OPTION_INCLUDE}. */
+    public static final String OPTION_EXCLUDE = "ts.scan.exclude";
+
+    /**
+     * Outcome of a scan: the types to declare, plus the names that were rejected because they could
+     * not be loaded. The skipped names are reported rather than swallowed — a class missing from the
+     * processor classpath is usually a build misconfiguration worth seeing.
+     */
+    public static final class Result {
+
+        private final Set<TSType> types;
+        private final List<String> skipped;
+
+        private Result(Set<TSType> types, List<String> skipped) {
+            this.types = types;
+            this.skipped = skipped;
+        }
+
+        static Result empty() {
+            return new Result(Collections.emptySet(), Collections.emptyList());
+        }
+
+        /** The types to declare, ordered by class name. */
+        public Set<TSType> types() {
+            return types;
+        }
+
+        /** Binary names that matched the filters but could not be loaded, with the failure cause. */
+        public List<String> skipped() {
+            return skipped;
+        }
+    }
+
+    private final List<Path> roots;
+    private final List<String> includes;
+    private final List<String> excludes;
+
+    private ClasspathScanner(List<Path> roots, List<String> includes, List<String> excludes) {
+        this.roots = roots;
+        this.includes = includes;
+        this.excludes = excludes;
+    }
+
+    /**
+     * Build a scanner from annotation processor options.
+     *
+     * @param options the processor option map
+     * @return        a scanner, or empty when {@link #OPTION_SCAN} is not set
+     */
+    public static Optional<ClasspathScanner> from(Map<String, String> options) {
+
+        final String scan = options.get(OPTION_SCAN);
+
+        if (scan == null || scan.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        final List<Path> roots = Arrays.stream(scan.split(java.io.File.pathSeparator))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Paths::get)
+                .collect(Collectors.toList());
+
+        return Optional.of(new ClasspathScanner(roots,
+                prefixes(options.get(OPTION_INCLUDE)),
+                prefixes(options.get(OPTION_EXCLUDE))));
+    }
+
+    private static List<String> prefixes(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Scan the configured roots.
+     *
+     * @return the types to declare and the names that could not be loaded
+     */
+    public Result scan() {
+
+        // TreeMap: the emitted declarations must not reorder between builds.
+        final Map<String, TSType> found = new TreeMap<>();
+        final List<String> skipped = new ArrayList<>();
+
+        for (final Path root : roots) {
+            for (final String binaryName : binaryNames(root)) {
+                if (!matchesFilters(binaryName)) {
+                    continue;
+                }
+                try {
+                    final Class<?> type = TSType.loadClass(binaryName);
+                    if (isPublicApiType(type) && type.getPackage() != null) {
+                        found.put(binaryName, TSType.of(type));
+                    }
+                } catch (Throwable t) {
+                    // A class whose supertype or a referenced type is absent cannot be introspected
+                    // by the transformers either, so skipping it here is the same outcome, reported
+                    // earlier and with a name attached.
+                    skipped.add(String.format("%s (%s)", binaryName, t));
+                }
+            }
+        }
+
+        return new Result(new LinkedHashSet<>(found.values()), skipped);
+    }
+
+    /**
+     * The binary names of every class file under a root, which may be a directory or a jar. A root
+     * that does not exist yields nothing: build layouts routinely list output directories that a
+     * given module never produces.
+     */
+    private List<String> binaryNames(Path root) {
+
+        if (Files.isDirectory(root)) {
+            try (Stream<Path> files = Files.walk(root)) {
+                return files.filter(Files::isRegularFile)
+                        .map(root::relativize)
+                        .map(Path::toString)
+                        .filter(name -> name.endsWith(".class"))
+                        .map(name -> toBinaryName(name.replace(java.io.File.separatorChar, '/')))
+                        .filter(name -> !isInfoClass(name))
+                        .collect(Collectors.toList());
+            } catch (IOException e) {
+                throw new UncheckedIOException("cannot scan directory " + root, e);
+            }
+        }
+
+        if (Files.isRegularFile(root)) {
+            try (ZipFile zip = new ZipFile(root.toFile())) {
+                final List<String> names = new ArrayList<>();
+                final Enumeration<? extends ZipEntry> entries = zip.entries();
+                while (entries.hasMoreElements()) {
+                    final String name = entries.nextElement().getName();
+                    // META-INF/versions/N/... duplicates classes under a release-specific path, and
+                    // module-info/package-info carry no declarable type.
+                    if (name.endsWith(".class") && !name.startsWith("META-INF/")) {
+                        final String binaryName = toBinaryName(name);
+                        if (!isInfoClass(binaryName)) {
+                            names.add(binaryName);
+                        }
+                    }
+                }
+                return names;
+            } catch (IOException e) {
+                throw new UncheckedIOException("cannot scan archive " + root, e);
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private static String toBinaryName(String resourceName) {
+        return resourceName.substring(0, resourceName.length() - ".class".length()).replace('/', '.');
+    }
+
+    private static boolean isInfoClass(String binaryName) {
+        return binaryName.endsWith("package-info") || binaryName.endsWith("module-info");
+    }
+
+    private boolean matchesFilters(String binaryName) {
+
+        if (!includes.isEmpty() && includes.stream().noneMatch(binaryName::startsWith)) {
+            return false;
+        }
+        return excludes.stream().noneMatch(binaryName::startsWith);
+    }
+
+    /**
+     * Whether a type is part of the public API surface: public itself, and — when nested — enclosed
+     * only by public types. Applied recursively, since {@code Outer.Middle.Inner} is reachable only
+     * if every level is.
+     */
+    private static boolean isPublicApiType(Class<?> type) {
+
+        if (!Modifier.isPublic(type.getModifiers()) || type.isSynthetic()) {
+            return false;
+        }
+
+        final Class<?> enclosing = type.getEnclosingClass();
+
+        if (enclosing == null) {
+            return true; // top level
+        }
+        if (!type.isMemberClass()) {
+            return false; // anonymous or local
+        }
+        return isPublicApiType(enclosing);
+    }
+}

--- a/core/src/main/java/org/bsc/java2typescript/Java2TSConverter.java
+++ b/core/src/main/java/org/bsc/java2typescript/Java2TSConverter.java
@@ -17,6 +17,7 @@ public class Java2TSConverter extends TSConverterStatic {
 
         private Compatibility compatibility = Compatibility.NASHORN;
         private boolean foreignObjectPrototype = false;
+        private boolean ignoreDeprecated = false;
 
         private Builder() {}
 
@@ -45,6 +46,12 @@ public class Java2TSConverter extends TSConverterStatic {
             return this;
         }
 
+        public Builder ignoreDeprecated(boolean ignoreDeprecated) {
+            this.ignoreDeprecated = ignoreDeprecated;
+            return this;
+        }
+
+
         public Builder foreignObjectPrototype(String foreignObjectPrototype) {
             this.foreignObjectPrototype =
                     Optional.ofNullable(foreignObjectPrototype)
@@ -62,7 +69,7 @@ public class Java2TSConverter extends TSConverterStatic {
 
         public Java2TSConverter build() {
             return new Java2TSConverter(
-                    new Options( compatibility, foreignObjectPrototype) );
+                    new Options( compatibility, foreignObjectPrototype, ignoreDeprecated) );
         }
     }
 
@@ -87,22 +94,24 @@ public class Java2TSConverter extends TSConverterStatic {
     public static class Options {
         public final Compatibility compatibility;
         public final boolean foreignObjectPrototype;
+        public final boolean ignoreDeprecated;
 
-        private Options(Compatibility compatibility, boolean foreignObjectPrototype) {
+        private Options(Compatibility compatibility, boolean foreignObjectPrototype, boolean ignoreDeprecated) {
             this.compatibility = compatibility;
             this.foreignObjectPrototype = foreignObjectPrototype;
+            this.ignoreDeprecated = ignoreDeprecated;
         }
 
-        public static Options of(Compatibility compatibility, boolean foreignObjectPrototype) {
-            return new Options(compatibility, foreignObjectPrototype);
+        public static Options of(Compatibility compatibility, boolean foreignObjectPrototype, boolean ignoreDeprecated) {
+            return new Options(compatibility, foreignObjectPrototype, ignoreDeprecated);
         }
 
         public static Options of(Compatibility compatibility) {
-            return new Options(compatibility, false);
+            return new Options(compatibility, false, false);
         }
 
         public static Options ofDefault() {
-            return new Options(Compatibility.NASHORN, false);
+            return new Options(Compatibility.NASHORN, false, false);
         }
     }
 

--- a/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
@@ -73,6 +73,7 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
     public TSConverterContext getClassDecl() {
 
         final StringBuilder inherited = new StringBuilder();
+        final StringBuilder realExtends = new StringBuilder();
 
         if (type.getValue().isInterface()) {
             sb.append("interface ");
@@ -86,11 +87,20 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
 
             sb.append("class ");
 
-            final TSType superclass = TSType.of(type.getValue().getSuperclass());
+            final Class<?> emittedSuper = emittedNonGenericSuperclass(type.getValue(), declaredTypeMap);
 
-            if (superclass != null) {
-                inherited.append(" extends ")
-                        .append(getTypeName(superclass, type, true));
+            if (emittedSuper != null) {
+                // Real inheritance: extend the emitted parent so its members are not re-listed
+                // (see the member filtering in TSJavaClass2DeclarationTransformer).
+                realExtends.append(" extends ")
+                        .append(getTypeName(TSType.of(emittedSuper), type, true));
+            } else {
+                final TSType superclass = TSType.of(type.getValue().getSuperclass());
+
+                if (superclass != null) {
+                    inherited.append(" extends ")
+                            .append(getTypeName(superclass, type, true));
+                }
             }
         }
 
@@ -108,6 +118,7 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
         }
 
         sb.append(getTypeName(type, type, true));
+        sb.append(realExtends);
 
         if (inherited.length() > 0 || type.hasAlias()) {
 

--- a/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
@@ -242,6 +242,37 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
         return result.append("( ").append(params_string).append(" ):").append(tsReturnType).toString();
     }
 
+    /**
+     * Render a public field as a TypeScript property declaration, e.g.
+     * {@code static readonly FOO:string} or {@code name:int}. Enum constants are handled
+     * separately (see {@link #processEnumDecl()}) and should be filtered out before calling this.
+     *
+     * @param f the field
+     * @return the TypeScript property declaration (without the trailing separator)
+     */
+    public String getFieldDecl(final Field f) {
+
+        final StringBuilder sb = new StringBuilder();
+
+        final int mod = f.getModifiers();
+
+        if (Modifier.isStatic(mod)) {
+            // 'static' is illegal on a TS interface member; comment it out as getMethodDecl does.
+            if (type.getValue().isInterface())
+                sb.append("// ");
+            sb.append("static ");
+        }
+
+        if (Modifier.isFinal(mod))
+            sb.append("readonly ");
+
+        sb.append(f.getName())
+                .append(':')
+                .append(convertJavaToTS(f.getGenericType(), f, type, declaredTypeMap, true, Optional.empty()));
+
+        return sb.toString();
+    }
+
     public String getMethodDecl(final Method m, boolean optional) {
 
         final StringBuilder sb = new StringBuilder();

--- a/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
@@ -257,9 +257,6 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
         final int mod = f.getModifiers();
 
         if (Modifier.isStatic(mod)) {
-            // 'static' is illegal on a TS interface member; comment it out as getMethodDecl does.
-            if (type.getValue().isInterface())
-                sb.append("// ");
             sb.append("static ");
         }
 
@@ -317,10 +314,6 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
         final StringBuilder sb = new StringBuilder();
 
         if (Modifier.isStatic(m.getModifiers())) {
-
-            if (type.getValue().isInterface()) {
-                sb.append("// ");
-            }
 
             sb.append("static ").append(m.getName());
         } else {

--- a/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
@@ -224,9 +224,12 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
 
             }
 
-            final String typeName = convertJavaToTS(tp.getParameterizedType(), m, type, declaredTypeMap,
+            final Type parameterizedType = tp.getParameterizedType();
+            final String typeName = convertJavaToTS(parameterizedType, m, type, declaredTypeMap,
                     packageResolution, Optional.of(addTypeVar));
-            return String.format("%s:%s", name, typeName);
+            return String.format("%s:%s", name,
+                    arrayWidenedCollectionParam(m, parameterizedType, typeName, packageResolution,
+                            Optional.of(addTypeVar)));
         }).collect(Collectors.joining(", "));
 
         final Type returnType = (m instanceof Method) ? ((Method) m).getGenericReturnType() : type.getValue();
@@ -300,13 +303,44 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
             } else {
                 final String typeName =
                         convertJavaToTS(p.getParameterizedType(), c, type, declaredTypeMap, true, Optional.empty());
-                params.append(String.format("%s:%s", name, typeName));
+                params.append(String.format("%s:%s", name,
+                        arrayWidenedCollectionParam(c, p.getParameterizedType(), typeName, true, Optional.empty())));
             }
         }
 
         params.append(" )");
 
         return "constructor".concat(params.toString());
+    }
+
+    /**
+     * Widen a Collection/Iterable PARAMETER type so it also accepts a plain TS array: GraalJS
+     * auto-converts a JS array to a java.util.List/Collection when it is passed to a Java
+     * method/constructor. Only parameters are widened (return types are rendered elsewhere), so a
+     * returned List keeps its full interface (add/get/size/...) for use from the script. Non
+     * Collection/Iterable types and raw (non-parameterized) usages are returned unchanged.
+     */
+    private <E extends Executable & Member> String arrayWidenedCollectionParam(E m, Type parameterizedType,
+            String typeName, boolean packageResolution, Optional<Consumer<TypeVariable<?>>> onTypeMismatch) {
+        if (!(parameterizedType instanceof ParameterizedType)) {
+            return typeName;
+        }
+        final ParameterizedType pt = (ParameterizedType) parameterizedType;
+        if (!(pt.getRawType() instanceof Class)) {
+            return typeName;
+        }
+        final Class<?> raw = (Class<?>) pt.getRawType();
+        final Type[] args = pt.getActualTypeArguments();
+        if (args.length != 1
+                || !(java.util.Collection.class.isAssignableFrom(raw) || Iterable.class.isAssignableFrom(raw))) {
+            return typeName;
+        }
+        // A bare WildcardType element (e.g. List<? extends Foo>) is not convertible on its own;
+        // `any` is fine for an input array (GraalJS coerces the elements).
+        final String elem = (args[0] instanceof WildcardType)
+                ? "any"
+                : convertJavaToTS(args[0], m, type, declaredTypeMap, packageResolution, onTypeMismatch);
+        return String.format("%s | (%s)[]", typeName, elem);
     }
 
     public String getMethodDecl(final Method m, boolean optional) {

--- a/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSConverterContext.java
@@ -273,6 +273,45 @@ public class TSConverterContext extends TSConverterStatic implements Cloneable, 
         return sb.toString();
     }
 
+    /**
+     * Render a public constructor as a TypeScript {@code constructor( ... )} declaration for use
+     * inside a {@code declare class}. Unlike a construct signature ({@code new(...)}), a TS
+     * constructor cannot carry its own type parameters, so none are emitted here; type variables
+     * that belong to the declaring class stay in scope, any others degrade to {@code any}.
+     *
+     * @param c the constructor
+     * @return the TypeScript constructor declaration (without the trailing separator)
+     */
+    public String getConstructorDecl(final Constructor<?> c) {
+
+        final StringBuilder params = new StringBuilder("( ");
+
+        final Parameter[] ps = c.getParameters();
+        for (int i = 0; i < ps.length; i++) {
+            if (i > 0)
+                params.append(", ");
+
+            final Parameter p = ps[i];
+            final String name = getParameterName(p);
+
+            if (p.isVarArgs()) {
+                final Type component = (p.getParameterizedType() instanceof GenericArrayType)
+                        ? ((GenericArrayType) p.getParameterizedType()).getGenericComponentType()
+                        : p.getType().getComponentType();
+                final String typeName = convertJavaToTS(component, c, type, declaredTypeMap, true, Optional.empty());
+                params.append(String.format("...%s:%s[]", name, typeName));
+            } else {
+                final String typeName =
+                        convertJavaToTS(p.getParameterizedType(), c, type, declaredTypeMap, true, Optional.empty());
+                params.append(String.format("%s:%s", name, typeName));
+            }
+        }
+
+        params.append(" )");
+
+        return "constructor".concat(params.toString());
+    }
+
     public String getMethodDecl(final Method m, boolean optional) {
 
         final StringBuilder sb = new StringBuilder();

--- a/core/src/main/java/org/bsc/java2typescript/TSConverterStatic.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSConverterStatic.java
@@ -36,8 +36,25 @@ import java.util.stream.Stream;
  *
  */
 public abstract class TSConverterStatic {
-    
+
     public static final String ENDL = ";\n";
+
+    /**
+     * The superclass to actually {@code extends} in the emitted declaration, or {@code null} to
+     * keep the flat (all-members-inlined) form. Real inheritance is used only when the superclass
+     * is itself emitted (present in {@code declaredTypeMap}), is not {@link Object} (which maps to
+     * {@code any}, so {@code extends} would be illegal), and is non-generic (a generic supertype
+     * would need its type arguments rendered — deferred). Enums/interfaces never extend a class.
+     */
+    protected static Class<?> emittedNonGenericSuperclass(Class<?> c,
+            java.util.Map<String, TSType> declaredTypeMap) {
+        if (c == null || c.isInterface() || c.isEnum()) return null;
+        final Class<?> s = c.getSuperclass();
+        if (s == null || s == Object.class) return null;
+        if (!declaredTypeMap.containsKey(s.getName())) return null;
+        if (s.getTypeParameters().length > 0) return null;
+        return s;
+    }
 
     public static final List<TSType> PREDEFINED_TYPES = Arrays.asList(
             TSType.of(Class.class),

--- a/core/src/main/java/org/bsc/java2typescript/TSConverterStatic.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSConverterStatic.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.RandomAccess;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
@@ -46,6 +47,69 @@ public abstract class TSConverterStatic {
             TSType.of(Cloneable.class),
             TSType.of(RandomAccess.class)
          );
+
+    public static final Set<String> RESERVED_TS_KEYWORDS = Set.of(
+        "break",
+        "case",
+        "catch",
+        "class",
+        "const",
+        "continue",
+        "debugger",
+        "default",
+        "delete",
+        "do",
+        "else",
+        "enum",
+        "export",
+        "extends",
+        "false",
+        "finally",
+        "for",
+        "function",
+        "if",
+        "import",
+        "in",
+        "instanceof",
+        "new",
+        "null",
+        "return",
+        "super",
+        "switch",
+        "this",
+        "throw",
+        "true",
+        "try",
+        "typeof",
+        "var",
+        "void",
+        "while",
+        "with",
+        "as",
+        "implements",
+        "interface",
+        "let",
+        "package",
+        "private",
+        "protected",
+        "public",
+        "static",
+        "yield",
+        "any",
+        "boolean",
+        "constructor",
+        "declare",
+        "get",
+        "module",
+        "require",
+        "number",
+        "set",
+        "string",
+        "symbol",
+        "type",
+        "from",
+        "of"
+    );
 
 
     /**
@@ -78,13 +142,7 @@ public abstract class TSConverterStatic {
     */
    public static final String getParameterName( Parameter p ) {
        final String name = p.getName();
-
-       switch( name ) {
-       case "function":
-           return "func";
-       default:
-           return name;
-       }
+        return RESERVED_TS_KEYWORDS.contains(name) ?  name + "_p" : name;
    }
 
    /**

--- a/core/src/main/java/org/bsc/java2typescript/TSType.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSType.java
@@ -183,7 +183,14 @@ public class TSType extends HashMap<String, Object> {
      * @return
      */
     protected boolean testIncludeMethod( Method m ) {
-        return !m.isBridge() && !m.isSynthetic() && Modifier.isPublic(m.getModifiers())
+        final int mod = m.getModifiers();
+        // Public members are API. A `protected abstract` method is also part of the callable
+        // contract: every concrete subclass must implement it, so instances handed to a script
+        // (via host interop) always expose it -- e.g. WebSocketAlertWrapper.WebSocketAlertBuilder.raise().
+        // Ordinary protected/private concrete methods stay excluded.
+        final boolean visible = Modifier.isPublic(mod)
+                || (Modifier.isProtected(mod) && Modifier.isAbstract(mod));
+        return !m.isBridge() && !m.isSynthetic() && visible
                 && Character.isJavaIdentifierStart(m.getName().charAt(0))
                 && m.getName().chars().skip(1).allMatch(Character::isJavaIdentifierPart);
     }

--- a/core/src/main/java/org/bsc/java2typescript/TSType.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSType.java
@@ -213,11 +213,23 @@ public class TSType extends HashMap<String, Object> {
      * @return
      */
     private Class<?> getMemberClassForName( String fqn ) throws ClassNotFoundException {
-        final char[] ch = fqn.toCharArray();
-        final int i = fqn.lastIndexOf('.');
-        ch[i] = '$';
+        // The source form of a nested type uses '.' for both the package separator and the nesting
+        // separator (e.g. a.b.Outer.Inner), but the binary name the class loader expects uses '$'
+        // for nesting (a.b.Outer$Inner). We don't know where the package ends, so convert trailing
+        // dots to '$' one at a time, right to left, and return the first name that resolves. This
+        // handles arbitrarily nested types (a.b.Outer$Middle$Inner), not just a single level.
+        final StringBuilder name = new StringBuilder(fqn);
+        int i;
+        while ((i = name.lastIndexOf(".")) >= 0) {
+            name.setCharAt(i, '$');
+            try {
+                return loadClass(name.toString());
+            } catch (ClassNotFoundException ignored) {
+                // Not this split; convert the next dot to the left and retry.
+            }
+        }
 
-        return loadClass(String.valueOf(ch));
+        throw new ClassNotFoundException(fqn);
     }
 
     /**

--- a/core/src/main/java/org/bsc/java2typescript/TSType.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSType.java
@@ -213,13 +213,29 @@ public class TSType extends HashMap<String, Object> {
      * @return
      */
     private Class<?> getMemberClassForName( String fqn ) throws ClassNotFoundException {
-        char[] ch = fqn.toCharArray();
-        int i = fqn.lastIndexOf('.');
+        final char[] ch = fqn.toCharArray();
+        final int i = fqn.lastIndexOf('.');
         ch[i] = '$';
 
-        return Class.forName(String.valueOf(ch));   
+        return loadClass(String.valueOf(ch));
     }
-    
+
+    /**
+     * Load a class WITHOUT running its static initializers.
+     * <p>
+     * Type generation only needs class metadata (methods, fields, modifiers). Initializing an
+     * application's classes outside their own runtime (as the 1-arg {@link Class#forName(String)}
+     * would) can trigger {@link ExceptionInInitializerError}: e.g. classes whose static
+     * initializers rely on framework state that has not been bootstrapped.
+     *
+     * @param fqn fully qualified class name
+     * @return the (uninitialized) loaded class
+     * @throws ClassNotFoundException if the class cannot be found
+     */
+    private static Class<?> loadClass(String fqn) throws ClassNotFoundException {
+        return Class.forName(fqn, false, TSType.class.getClassLoader());
+    }
+
     /**
      *
      * @param dt
@@ -231,7 +247,7 @@ public class TSType extends HashMap<String, Object> {
 
         final String fqn = dt.toString();
         try {
-            return Class.forName(fqn);
+            return loadClass(fqn);
 
         } catch (ClassNotFoundException e1) {
 

--- a/core/src/main/java/org/bsc/java2typescript/TSType.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSType.java
@@ -23,6 +23,7 @@ public class TSType extends HashMap<String, Object> {
     private static final String EXPORT = "export";
     private static final String NAMESPACE = "namespace";
     private static final String FUNCTIONAL = "functional";
+    private static final String DECLARE = "declare";
 
     protected TSType() {
         super(3);
@@ -58,6 +59,20 @@ public class TSType extends HashMap<String, Object> {
      */
     public boolean isExport() {
         return (boolean) super.getOrDefault(EXPORT, false);
+    }
+
+    /**
+     * Whether this type is emitted as a declaration (and added to the type registry). A type with
+     * {@code declare == false} is kept only for name resolution / as an {@code extends} target,
+     * because it is declared in another generated file. Defaults to true.
+     */
+    public boolean isDeclare() {
+        return (boolean) super.getOrDefault(DECLARE, true);
+    }
+
+    public TSType setDeclare(boolean value) {
+        super.put(DECLARE, value);
+        return this;
     }
 
     /**

--- a/core/src/main/java/org/bsc/java2typescript/TSType.java
+++ b/core/src/main/java/org/bsc/java2typescript/TSType.java
@@ -266,7 +266,7 @@ public class TSType extends HashMap<String, Object> {
      * @return the (uninitialized) loaded class
      * @throws ClassNotFoundException if the class cannot be found
      */
-    private static Class<?> loadClass(String fqn) throws ClassNotFoundException {
+    static Class<?> loadClass(String fqn) throws ClassNotFoundException {
         return Class.forName(fqn, false, TSType.class.getClassLoader());
     }
 

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -170,13 +170,49 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
         ctx.append("\n} // end ").append(tstype.getSimpleTypeName()).append('\n');
 
-        // NESTED CLASSES
-        // if( level == 0 ) ctx.processMemberClasses( level );
+        appendNestedTypeAliases(ctx, tstype);
 
         if (tstype.supportNamespace())
             ctx.append("\n} // end namespace ").append(tstype.getNamespace()).append('\n');
 
         return ctx;
+    }
+
+    /**
+     * GraalJS accesses a nested Java type as {@code Outer.Inner}, but nested types are emitted
+     * flattened as {@code Outer$Inner} siblings in the package namespace. Emit a
+     * {@code namespace Outer { ... }} that merges with the {@code class Outer} and re-exposes each
+     * nested type under its simple name, so both {@code Outer.Inner} (GraalJS form) and
+     * {@code Outer$Inner} (flattened form) resolve. Only nested types that were themselves emitted
+     * (present in the declared-type map) are aliased.
+     */
+    private void appendNestedTypeAliases(TSConverterContext ctx, TSType tstype) {
+        final StringBuilder body = new StringBuilder();
+        for (Class<?> nested : tstype.getValue().getDeclaredClasses()) {
+            if (!Modifier.isPublic(nested.getModifiers()) || nested.isSynthetic()) continue;
+            if (!ctx.declaredTypeMap.containsKey(nested.getName())) continue;
+
+            final String simple = nested.getSimpleName();
+            final String flattened = TSType.of(nested).getSimpleTypeName(); // Outer$Inner
+            final java.lang.reflect.TypeVariable<?>[] tps = nested.getTypeParameters();
+            final String tp = (tps.length == 0) ? "" : Stream.of(tps)
+                    .map(java.lang.reflect.TypeVariable::getName)
+                    .collect(Collectors.joining(",", "<", ">"));
+
+            body.append('\t').append("export type ").append(simple).append(tp)
+                    .append(" = ").append(flattened).append(tp).append(ENDL);
+            // A nested interface has no runtime value; classes and enums do (constructor / enum
+            // object), so only they get a value alias for `Outer.Inner` value access.
+            if (!nested.isInterface()) {
+                body.append('\t').append("export const ").append(simple)
+                        .append(": typeof ").append(flattened).append(ENDL);
+            }
+        }
+        if (body.length() > 0) {
+            ctx.append("namespace ").append(tstype.getSimpleTypeName()).append(" {\n")
+                    .append(body.toString())
+                    .append("} // end nested aliases of ").append(tstype.getSimpleTypeName()).append('\n');
+        }
     }
 
     /**

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -139,6 +139,14 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
                 .sorted()
                 .forEach( decl -> ctx.append('\t').append(decl).append(ENDL));
 
+            // Public constructors. Interfaces have none (getConstructors() is empty), so no invalid
+            // 'constructor' is emitted into a TS interface.
+            Stream.of(tstype.getValue().getConstructors())
+                .filter( c -> Modifier.isPublic(c.getModifiers()) )
+                .map( ctx::getConstructorDecl )
+                .sorted()
+                .forEach( decl -> ctx.append('\t').append(decl).append(ENDL));
+
             methods.stream()
                 .filter( md -> (tstype.isExport() && isStatic(md)) == false)
                 .filter( this::testMethodNotAllowed)

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -134,6 +134,14 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
             ctx.processEnumDecl();
 
+            // Every Java class value exposes `.class` (its java.lang.Class object). Emit it as a
+            // static member so `SomeClass.class` type-checks. Interfaces reach this branch too but
+            // have no runtime value / static side (and `static` is illegal on a TS interface), so
+            // skip them.
+            if (!tstype.getValue().isInterface()) {
+                ctx.append('\t').append("static class:java.lang.Class<any>;").append(ENDL);
+            }
+
             // Public fields (class values). Enum constants are emitted by processEnumDecl / the
             // static definition, so exclude them here to avoid duplicate declarations.
             tstype.getFields().stream()

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -131,6 +131,14 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
             ctx.processEnumDecl();
 
+            // Public fields (class values). Enum constants are emitted by processEnumDecl / the
+            // static definition, so exclude them here to avoid duplicate declarations.
+            tstype.getFields().stream()
+                .filter( f -> !f.isEnumConstant() )
+                .map( ctx::getFieldDecl )
+                .sorted()
+                .forEach( decl -> ctx.append('\t').append(decl).append(ENDL));
+
             methods.stream()
                 .filter( md -> (tstype.isExport() && isStatic(md)) == false)
                 .filter( this::testMethodNotAllowed)

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -5,6 +5,7 @@ import org.bsc.java2typescript.TSConverterStatic;
 import org.bsc.java2typescript.TSTransformer;
 import org.bsc.java2typescript.TSType;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Set;
@@ -23,6 +24,13 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
      * @param md
      * @return
      */
+    /** Erased name+parameter-types signature, used to match a method against an inherited one. */
+    private static String methodSig(Method m) {
+        return m.getName() + Stream.of(m.getParameterTypes())
+                .map(Class::getName)
+                .collect(Collectors.joining(",", "(", ")"));
+    }
+
     protected boolean testMethodNotAllowed(Method md ) {
         final String name = md.getName();
         return !(name.contains("$")     || // remove unnamed
@@ -102,7 +110,26 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
         if (tstype.getValue().isEnum())
             return applyEnum(ctx, tstype);
 
-        final Set<Method> methods = getMethodsAsStream(ctx).collect(Collectors.toSet());;
+        // When the class really `extends` an emitted parent (see getClassDecl), the parent's
+        // members are inherited in TS and must not be re-listed. Drop every method whose name is
+        // fully covered by the parent; keep ALL overloads of any name the class also declares a new
+        // overload of (a subclass method declaration shadows the parent's overloads of that name in
+        // TS, so a partial list would lose the inherited ones).
+        final Class<?> emittedSuper = emittedNonGenericSuperclass(tstype.getValue(), ctx.declaredTypeMap);
+
+        Set<Method> methods = getMethodsAsStream(ctx).collect(Collectors.toSet());
+        if (emittedSuper != null) {
+            final Set<String> parentSigs = Stream.of(emittedSuper.getMethods())
+                    .map(TSJavaClass2DeclarationTransformer::methodSig)
+                    .collect(Collectors.toSet());
+            final Set<String> newNames = methods.stream()
+                    .filter(m -> !parentSigs.contains(methodSig(m)))
+                    .map(Method::getName)
+                    .collect(Collectors.toSet());
+            methods = methods.stream()
+                    .filter(m -> newNames.contains(m.getName()))
+                    .collect(Collectors.toSet());
+        }
 
         if (tstype.supportNamespace())
             ctx.append("declare namespace ")
@@ -139,13 +166,18 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
             // have no runtime value / static side (and `static` is illegal on a TS interface), so
             // skip them.
             if (!tstype.getValue().isInterface()) {
-                ctx.append('\t').append("static class:java.lang.Class<any>;").append(ENDL);
+                ctx.append('\t').append("static class:java.lang.Class<any>").append(ENDL);
             }
 
             // Public fields (class values). Enum constants are emitted by processEnumDecl / the
-            // static definition, so exclude them here to avoid duplicate declarations.
+            // static definition, so exclude them here to avoid duplicate declarations. When
+            // extending an emitted parent, drop fields inherited from it (they come via `extends`).
+            final Set<String> parentFieldNames = (emittedSuper == null)
+                    ? java.util.Collections.emptySet()
+                    : Stream.of(emittedSuper.getFields()).map(Field::getName).collect(Collectors.toSet());
             tstype.getFields().stream()
                 .filter( f -> !f.isEnumConstant() )
+                .filter( f -> !parentFieldNames.contains(f.getName()) )
                 .map( ctx::getFieldDecl )
                 .sorted()
                 .forEach( decl -> ctx.append('\t').append(decl).append(ENDL));

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -137,6 +137,9 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
         final TSType tstype = ctx.type;
 
+        
+        if (ctx.options.ignoreDeprecated && tstype.getValue().getAnnotation(Deprecated.class) != null)
+            return ctx;
         if (tstype.getValue().isEnum())
             return applyEnum(ctx, tstype);
 
@@ -147,7 +150,9 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
         // TS, so a partial list would lose the inherited ones).
         final Class<?> emittedSuper = emittedNonGenericSuperclass(tstype.getValue(), ctx.declaredTypeMap);
 
-        Set<Method> methods = getMethodsAsStream(ctx).collect(Collectors.toSet());
+        Set<Method> methods = getMethodsAsStream(ctx)
+                                .filter( md -> !ctx.options.ignoreDeprecated || md.getAnnotation(Deprecated.class) == null)
+                                .collect(Collectors.toSet());
         if (emittedSuper != null) {
             final Map<String, Set<Class<?>>> parentReturnTypes = returnTypesBySig(emittedSuper);
             final Set<String> newNames = methods.stream()
@@ -206,6 +211,7 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
             tstype.getFields().stream()
                 .filter( f -> !f.isEnumConstant() )
                 .filter( f -> !parentFieldNames.contains(f.getName()) )
+                .filter( f -> !ctx.options.ignoreDeprecated || f.getAnnotation(Deprecated.class) == null)
                 .map( ctx::getFieldDecl )
                 .sorted()
                 .forEach( decl -> ctx.append('\t').append(decl).append(ENDL));
@@ -214,6 +220,7 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
             // 'constructor' is emitted into a TS interface.
             Stream.of(tstype.getValue().getConstructors())
                 .filter( c -> Modifier.isPublic(c.getModifiers()) )
+                .filter( c -> !ctx.options.ignoreDeprecated || c.getAnnotation(Deprecated.class) == null)
                 .map( ctx::getConstructorDecl )
                 .sorted()
                 .forEach( decl -> ctx.append('\t').append(decl).append(ENDL));
@@ -303,6 +310,7 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
         final String members = tstype.getFields().stream()
             .filter(java.lang.reflect.Field::isEnumConstant)
+            .filter(f -> !ctx.options.ignoreDeprecated || f.getAnnotation(Deprecated.class) == null)
             .map(java.lang.reflect.Field::getName)
             .sorted()
             .map(name -> String.format("\t%s = \"%s\"", name, name))

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -99,6 +99,9 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
         final TSType tstype = ctx.type;
 
+        if (tstype.getValue().isEnum())
+            return applyEnum(ctx, tstype);
+
         final Set<Method> methods = getMethodsAsStream(ctx).collect(Collectors.toSet());;
 
         if (tstype.supportNamespace())
@@ -159,6 +162,47 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
         // NESTED CLASSES
         // if( level == 0 ) ctx.processMemberClasses( level );
+
+        if (tstype.supportNamespace())
+            ctx.append("\n} // end namespace ").append(tstype.getNamespace()).append('\n');
+
+        return ctx;
+    }
+
+    /**
+     * Emit a Java enum as a native, string-valued TypeScript enum, e.g.
+     * <pre>
+     * declare namespace pkg {
+     * enum Mode {
+     * 	SAFE = "SAFE",
+     * 	PROTECTED = "PROTECTED"
+     * }
+     * } // end namespace pkg
+     * </pre>
+     * Each constant maps to its own name as a string so that GraalJS' read-as-string coercion
+     * (e.g. {@code plugin.getMode() == "SAFE"}) type-checks, while the nominal enum type still
+     * rejects passing a bare string where a Java enum is required — which GraalJS rejects at
+     * runtime too. The instance methods and Java {@code Enum} machinery are intentionally dropped.
+     *
+     * @param ctx    the conversion context
+     * @param tstype the enum type
+     * @return the context
+     */
+    private TSConverterContext applyEnum(TSConverterContext ctx, TSType tstype) {
+
+        if (tstype.supportNamespace())
+            ctx.append("declare namespace ").append(tstype.getNamespace()).append(" {\n\n");
+
+        ctx.append("enum ").append(tstype.getSimpleTypeName()).append(" {\n");
+
+        final String members = tstype.getFields().stream()
+            .filter(java.lang.reflect.Field::isEnumConstant)
+            .map(java.lang.reflect.Field::getName)
+            .sorted()
+            .map(name -> String.format("\t%s = \"%s\"", name, name))
+            .collect(Collectors.joining(",\n"));
+
+        ctx.append(members).append("\n}\n");
 
         if (tstype.supportNamespace())
             ctx.append("\n} // end namespace ").append(tstype.getNamespace()).append('\n');

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -8,6 +8,8 @@ import org.bsc.java2typescript.TSType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,6 +31,34 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
         return m.getName() + Stream.of(m.getParameterTypes())
                 .map(Class::getName)
                 .collect(Collectors.joining(",", "(", ")"));
+    }
+
+    /**
+     * The return types the parent chain declares for each signature.
+     * <p>
+     * A signature can map to several: a parent that itself narrows a grandparent's return type
+     * leaves both declarations visible through {@link Class#getMethods()}. Bridges are excluded so
+     * only real declarations are compared.
+     */
+    private static Map<String, Set<Class<?>>> returnTypesBySig(Class<?> type) {
+        return Stream.of(type.getMethods())
+                .filter(m -> !m.isBridge() && !m.isSynthetic())
+                .collect(Collectors.groupingBy(
+                        TSJavaClass2DeclarationTransformer::methodSig,
+                        Collectors.mapping(Method::getReturnType, Collectors.toSet())));
+    }
+
+    /**
+     * Whether a method is inherited from the parent unchanged, and so needs no declaration of its
+     * own — {@code extends} already provides it.
+     * <p>
+     * The signature alone is not enough: a covariant override has the same name and parameters as
+     * the method it overrides and differs only in its return type, so matching on signature would
+     * discard exactly the narrowing the override exists to express.
+     */
+    private static boolean isInheritedUnchanged(Method m, Map<String, Set<Class<?>>> parentReturnTypes) {
+        return parentReturnTypes.getOrDefault(methodSig(m), Collections.emptySet())
+                .contains(m.getReturnType());
     }
 
     protected boolean testMethodNotAllowed(Method md ) {
@@ -119,11 +149,9 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
 
         Set<Method> methods = getMethodsAsStream(ctx).collect(Collectors.toSet());
         if (emittedSuper != null) {
-            final Set<String> parentSigs = Stream.of(emittedSuper.getMethods())
-                    .map(TSJavaClass2DeclarationTransformer::methodSig)
-                    .collect(Collectors.toSet());
+            final Map<String, Set<Class<?>>> parentReturnTypes = returnTypesBySig(emittedSuper);
             final Set<String> newNames = methods.stream()
-                    .filter(m -> !parentSigs.contains(methodSig(m)))
+                    .filter(m -> !isInheritedUnchanged(m, parentReturnTypes))
                     .map(Method::getName)
                     .collect(Collectors.toSet());
             methods = methods.stream()

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2DeclarationTransformer.java
@@ -150,8 +150,10 @@ public class TSJavaClass2DeclarationTransformer extends TSConverterStatic implem
                 .sorted()
                 .forEach( decl -> ctx.append('\t').append(decl).append(ENDL));
 
+            // Emit every method, static included. Static methods carry the `static` keyword (see
+            // getMethodDecl), so `typeof <class>` exposes the full static side in the .d.ts and the
+            // runtime binding in <out>-types.ts collapses to `typeof <class>` (no duplicated list).
             methods.stream()
-                .filter( md -> (tstype.isExport() && isStatic(md)) == false)
                 .filter( this::testMethodNotAllowed)
                 .map( md -> ctx.getMethodDecl(md, false /* optional */) )
                 .sorted()

--- a/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2StaticDefinitionTransformer.java
+++ b/core/src/main/java/org/bsc/java2typescript/transformer/TSJavaClass2StaticDefinitionTransformer.java
@@ -20,11 +20,36 @@ public class TSJavaClass2StaticDefinitionTransformer extends TSConverterStatic i
     @Override
     public TSConverterContext apply(TSConverterContext ctx) {
 
-        ctx.append("interface ").append(ctx.type.getSimpleTypeName()).append("Static {\n\n");
+        // Classes and enums expose their full static side in the .d.ts declaration, so the runtime
+        // binding is simply `typeof <the declared type>` — no duplicated signatures. Interfaces have
+        // no value form (`typeof <interface>` is illegal), so they keep an explicit "…Static" type
+        // carrying the construct signature (functional SAM) and any static methods.
+        if (!ctx.type.getValue().isInterface()) {
 
-        if (ctx.type.getValue().isEnum()) {
-            ctx.processEnumType();
+            return ctx.append("export const ")
+                    .append(ctx.type.getSimpleTypeName())
+                    .append(": typeof ")
+                    .append(ctx.type.getTypeName())
+                    .append(" = ")
+                    .append(ctx.getOptions().compatibility.javaType(ctx.type.getValue().getName()))
+                    .append(ENDL)
+                    .append("\n");
         }
+
+        return applyInterfaceStatic(ctx);
+    }
+
+    /**
+     * Emit the {@code …Static} construct/static type for an interface, plus its {@code Java.type()}
+     * binding. Interfaces (notably functional ones) have no {@code typeof} value form, so their
+     * static side cannot be derived from the {@code .d.ts} declaration.
+     *
+     * @param ctx the conversion context
+     * @return the context
+     */
+    private TSConverterContext applyInterfaceStatic(TSConverterContext ctx) {
+
+        ctx.append("interface ").append(ctx.type.getSimpleTypeName()).append("Static {\n\n");
 
         // Append class property
         ctx.append("\treadonly class:any;\n");

--- a/core/src/main/resources/headerD.ts
+++ b/core/src/main/resources/headerD.ts
@@ -47,10 +47,16 @@ declare function load( module:string ):void
 
 declare namespace Java {
 
-  export function type<T>( t:string):T;
+  // Typed overload: for keys known to the generated registry, returns the concrete class
+  // (constructor + statics). Declared first so it takes precedence over the generic overload.
+  // {{REGISTRY_TYPE}} is substituted by the annotation processor (see the 'ts.registry' option).
+  export function type<K extends keyof {{REGISTRY_TYPE}}>( k:K ):{{REGISTRY_TYPE}}[K];
+
+  // Fallback so unknown class names still compile.
+  export function type<T>( t:string ):T;
 
   export function from<T>( list:java.util.List<T> ):Array<T> ;
-  
+
 }
 
 //

--- a/core/src/main/resources/headerD.ts
+++ b/core/src/main/resources/headerD.ts
@@ -57,6 +57,12 @@ declare namespace Java {
 
   export function from<T>( list:java.util.List<T> ):Array<T> ;
 
+  // Java.extend( SuperType, ...moreTypes ) returns a subclass "adapter" constructor. `new`-ing it
+  // takes the supertype constructor arguments followed by an object literal that
+  // overrides/implements the supertype's methods; the resulting instance is an InstanceType<T>.
+  // Typed loosely (args:any[]) since the forwarded ctor args and the override object vary per type.
+  export function extend<T extends new ( ...args:any[] ) => any>( type:T, ...moreTypes:any[] ):new ( ...args:any[] ) => InstanceType<T>;
+
 }
 
 //

--- a/core/src/main/resources/headerD.ts
+++ b/core/src/main/resources/headerD.ts
@@ -18,8 +18,9 @@ type chararray = [byte];
 type bytearray = [char];
 
 declare namespace java.lang {
-
-	interface Class<T> {}
+  	interface Class<T> {
+		getResource(res : string) : any /*java.net.URL*/
+	}
 	interface AutoCloseable {}
 	interface Cloneable {}
 

--- a/core/src/test/java/org/bsc/java2typescript/ClasspathScannerTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/ClasspathScannerTest.java
@@ -1,0 +1,163 @@
+package org.bsc.java2typescript;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link ClasspathScanner} selects the public API surface out of compiled class files.
+ */
+public class ClasspathScannerTest {
+
+    // --- fixtures: the scanner runs against this test class' own compiled output ---------------
+
+    public static class PublicNested {
+        public static class DeepPublic {
+        }
+    }
+
+    static class PackagePrivateNested {
+        /** Public, but unreachable from outside: the enclosing type is not. */
+        public static class PublicInsidePackagePrivate {
+        }
+    }
+
+    public interface PublicIface {
+    }
+
+    /** Compiles to an anonymous class (ClasspathScannerTest$1). */
+    public static final Runnable ANONYMOUS = new Runnable() {
+        @Override
+        public void run() {
+        }
+    };
+
+    private static final String PREFIX = ClasspathScannerTest.class.getName();
+
+    private static Path testClassesDir() throws Exception {
+        return Paths.get(ClasspathScannerTest.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI());
+    }
+
+    private static Map<String, String> options(String... keyValues) throws Exception {
+        final Map<String, String> options = new HashMap<>();
+        options.put(ClasspathScanner.OPTION_SCAN, testClassesDir().toString());
+        for (int i = 0; i < keyValues.length; i += 2) {
+            options.put(keyValues[i], keyValues[i + 1]);
+        }
+        return options;
+    }
+
+    private static List<String> scanNames(Map<String, String> options) {
+        return ClasspathScanner.from(options)
+                .orElseThrow(() -> new AssertionError("no scanner"))
+                .scan()
+                .types()
+                .stream()
+                .map(t -> t.getValue().getName())
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> fixtureNames() throws Exception {
+        return scanNames(options(ClasspathScanner.OPTION_INCLUDE, PREFIX));
+    }
+
+    @Test
+    public void noScannerWithoutTheScanOption() {
+        assertFalse(ClasspathScanner.from(Collections.emptyMap()).isPresent());
+        assertFalse(ClasspathScanner.from(
+                Collections.singletonMap(ClasspathScanner.OPTION_SCAN, "  ")).isPresent());
+    }
+
+    @Test
+    public void publicTypesAreIncluded() throws Exception {
+        final List<String> names = fixtureNames();
+
+        assertTrue(names.contains(PREFIX));
+        assertTrue(names.contains(PREFIX + "$PublicNested"));
+        assertTrue(names.contains(PREFIX + "$PublicNested$DeepPublic"));
+        assertTrue(names.contains(PREFIX + "$PublicIface"));
+    }
+
+    @Test
+    public void nonPublicAndUnreachableTypesAreExcluded() throws Exception {
+        final List<String> names = fixtureNames();
+
+        assertFalse(names.contains(PREFIX + "$PackagePrivateNested"));
+        // Public, but nested in a package-private type: not referenceable from outside.
+        assertFalse(names.contains(PREFIX + "$PackagePrivateNested$PublicInsidePackagePrivate"));
+        assertFalse(names.contains(PREFIX + "$1"));
+    }
+
+    @Test
+    public void excludeIsAppliedAfterInclude() throws Exception {
+        final List<String> names = scanNames(options(
+                ClasspathScanner.OPTION_INCLUDE, PREFIX,
+                ClasspathScanner.OPTION_EXCLUDE, PREFIX + "$PublicNested"));
+
+        assertTrue(names.contains(PREFIX));
+        assertFalse(names.contains(PREFIX + "$PublicNested"));
+        assertFalse(names.contains(PREFIX + "$PublicNested$DeepPublic"));
+    }
+
+    @Test
+    public void includeNarrowsToMatchingPrefixesOnly() throws Exception {
+        final List<String> names = scanNames(options(
+                ClasspathScanner.OPTION_INCLUDE, "org.bsc.does.not.exist"));
+
+        assertTrue(names.isEmpty());
+    }
+
+    @Test
+    public void resultIsOrderedByClassName() throws Exception {
+        final List<String> names = fixtureNames();
+        final List<String> sorted = new ArrayList<>(names);
+        Collections.sort(sorted);
+
+        assertEquals(sorted, names);
+    }
+
+    @Test
+    public void missingRootsAreIgnored() throws Exception {
+        final Map<String, String> options = new HashMap<>();
+        options.put(ClasspathScanner.OPTION_SCAN,
+                testClassesDir() + File.pathSeparator + "/no/such/place");
+        options.put(ClasspathScanner.OPTION_INCLUDE, PREFIX);
+
+        assertTrue(scanNames(options).contains(PREFIX));
+    }
+
+    @Test
+    public void jarRootsAreScanned() throws Exception {
+        // junit itself is on the test classpath as a jar: scanning it must yield its public API.
+        final Path jar = Paths.get(Test.class.getProtectionDomain()
+                .getCodeSource().getLocation().toURI());
+        final Map<String, String> options = new HashMap<>();
+        options.put(ClasspathScanner.OPTION_SCAN, jar.toString());
+        options.put(ClasspathScanner.OPTION_INCLUDE, "org.junit.Assert");
+
+        assertTrue(scanNames(options).contains("org.junit.Assert"));
+    }
+
+    @Test
+    public void skippedClassesAreReportedNotThrown() throws Exception {
+        final Optional<ClasspathScanner> scanner = ClasspathScanner.from(
+                options(ClasspathScanner.OPTION_INCLUDE, PREFIX));
+
+        // Nothing here is unloadable, so the run is clean; the point is that scan() completes.
+        assertTrue(scanner.get().scan().skipped().isEmpty());
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/CovariantOverrideTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/CovariantOverrideTest.java
@@ -1,0 +1,83 @@
+package org.bsc.java2typescript;
+
+import org.bsc.java2typescript.Java2TSConverter.Compatibility;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A subclass that narrows the return type of an inherited method must re-declare it.
+ * <p>
+ * Members of an emitted parent are inherited through {@code extends} and are deliberately not
+ * re-listed, but a covariant override is not the same member: dropping it leaves the parent's
+ * wider return type in force, which breaks the fluent builders it is normally used for
+ * ({@code b.setParam(..).raise()} would resolve {@code setParam} to the parent type).
+ *
+ * @see org.bsc.java2typescript.transformer.TSJavaClass2DeclarationTransformer
+ */
+public class CovariantOverrideTest extends AbstractConverterTest {
+
+    public static class Parent {
+        public Parent setValue(String value) { return this; }
+        public Parent setOther(int other) { return this; }
+        public String untouched() { return ""; }
+    }
+
+    public static class Child extends Parent {
+        @Override
+        public Child setValue(String value) { return this; }
+        public void raise() { }
+    }
+
+    /** Overrides the return type without narrowing it: nothing new to declare. */
+    public static class SameReturnChild extends Parent {
+        @Override
+        public Parent setValue(String value) { return this; }
+    }
+
+    private Java2TSConverter converter;
+
+    @Before
+    public void initConverter() {
+        converter = Java2TSConverter.builder().compatibility(Compatibility.NASHORN).build();
+    }
+
+    private String declarationOf(Class<?> type) {
+        return converter.javaClass2DeclarationTransformer(0, TSType.of(type),
+                declaredClassMap(Parent.class, Child.class, SameReturnChild.class));
+    }
+
+    @Test
+    public void narrowedReturnTypeIsRedeclared() {
+
+        final String result = declarationOf(Child.class);
+
+        assertTrue(result, result.contains("extends"));
+        assertTrue("setValue must be re-declared with the narrowed return type:\n" + result,
+                result.contains("setValue"));
+        assertTrue("the narrowed return type must be the child:\n" + result,
+                result.matches("(?s).*setValue\\([^)]*\\)\\s*:\\s*[^;]*Child.*"));
+    }
+
+    @Test
+    public void unchangedInheritedMembersAreStillNotRelisted() {
+
+        final String result = declarationOf(Child.class);
+
+        // setOther and untouched are inherited unchanged: they come through `extends`.
+        assertTrue("inherited-unchanged members must not be re-listed:\n" + result,
+                !result.contains("setOther") && !result.contains("untouched"));
+        // The class' own new member is of course declared.
+        assertTrue(result, result.contains("raise"));
+    }
+
+    @Test
+    public void overrideKeepingTheSameReturnTypeIsNotRedeclared() {
+
+        final String result = declarationOf(SameReturnChild.class);
+
+        assertTrue("an override that changes nothing adds no declaration:\n" + result,
+                !result.contains("setValue"));
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/DeprecatedTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/DeprecatedTest.java
@@ -1,0 +1,100 @@
+package org.bsc.java2typescript;
+
+import java.util.Collections;
+
+import org.bsc.java2typescript.Java2TSConverter.Compatibility;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * When using option "ignoreDeprecated", @Deprecated elements (classes, methods, fields...), will not be declared.
+ *
+ * @see TODO
+ */
+public class DeprecatedTest {
+
+    // 'type', 'string' and 'number' are TS reserved words but perfectly valid Java identifiers,
+    // so they survive to the reflection layer where getParameterName must rename them.
+    class Deprecations {
+        public static int validMember;
+        @Deprecated public static int invalidMember;
+        public void validMethod(String value) {};
+        @Deprecated public void invalidMethod(String value) {};
+        public class ValidClass { void m(){}; };
+        @Deprecated public class InvalidClass { void m(){}; };
+    }
+
+    enum WithDeprecatedConstant {
+        VALID,
+        @Deprecated INVALID
+    }
+
+    @Deprecated
+    public static class DeprecatedParent { }
+
+    public static class LiveChild extends DeprecatedParent { }
+
+
+    private Java2TSConverter converter;
+
+    @Before
+    public void initConverter() {
+        converter = Java2TSConverter.builder().compatibility(Compatibility.NASHORN).ignoreDeprecated(true).build();
+    }
+
+    @Test
+    public void deprecatedNotDeclared() {
+
+        final String result =
+                converter.javaClass2DeclarationTransformer(0, TSType.of(Deprecations.class), Collections.emptyMap());
+
+        assertNotNull(result);
+
+        // members fields
+        assertTrue(result, result.contains("static validMember:int"));
+        assertFalse(result, result.contains("static invalidMember:int"));
+
+        //methods
+        assertTrue(result, result.contains("validMethod( value:string )"));
+        assertFalse(result, result.contains("invalidMethod( value:string )"));
+
+        //classes
+        final String validClassRes =
+                converter.javaClass2DeclarationTransformer(0, TSType.of(Deprecations.ValidClass.class), Collections.emptyMap());
+        assertTrue(validClassRes, validClassRes.contains("class Deprecations$ValidClass"));
+        final String invalidClassRes =
+                converter.javaClass2DeclarationTransformer(0, TSType.of(Deprecations.InvalidClass.class), Collections.emptyMap());
+        assertFalse(invalidClassRes, invalidClassRes.contains("class Deprecations$InvalidClass"));
+    }
+
+    @Test
+    public void deprecatedEnumConstantNotDeclared() {
+
+        final String result =
+                converter.javaClass2DeclarationTransformer(0, TSType.of(WithDeprecatedConstant.class),
+                        Collections.emptyMap());
+
+        assertTrue(result, result.contains("VALID = \"VALID\""));
+        assertFalse(result, result.contains("INVALID"));
+    }
+
+    /**
+     * if parent is deprecated, undeprecated child should not extend it's parent.
+     * Seem like it shouldn't happen, but it exists in practice. (ex: legacy interfaces)
+     */
+    @Test
+    public void undeclaredParentIsExtendedOnlyInAComment() {
+
+        final String result =
+                converter.javaClass2DeclarationTransformer(0, TSType.of(LiveChild.class),
+                        // DeprecatedParent absent, as the processor leaves it once filtered out.
+                        Collections.singletonMap(LiveChild.class.getName(), TSType.of(LiveChild.class)));
+
+        assertTrue("the parent must be inert, inside a comment:\n" + result,
+                result.contains("class DeprecatedTest$LiveChild/* extends DeprecatedTest$DeprecatedParent*/"));
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/EnumDeclarationTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/EnumDeclarationTest.java
@@ -1,0 +1,51 @@
+package org.bsc.java2typescript;
+
+import java.util.Collections;
+
+import org.bsc.java2typescript.Java2TSConverter.Compatibility;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A Java enum is emitted as a native, string-valued TypeScript enum (not a class), so GraalJS'
+ * read-as-string coercion type-checks while a bare string is still rejected where the enum is
+ * required.
+ *
+ * @see org.bsc.java2typescript.transformer.TSJavaClass2DeclarationTransformer
+ */
+public class EnumDeclarationTest extends AbstractConverterTest {
+
+    enum Color { RED, GREEN, BLUE }
+
+    private Java2TSConverter converter;
+
+    @Before
+    public void initConverter() {
+        converter = Java2TSConverter.builder().compatibility(Compatibility.NASHORN).build();
+    }
+
+    @Test
+    public void enumBecomesNativeStringEnum() {
+
+        final String result =
+                converter.javaClass2DeclarationTransformer(0, TSType.of(Color.class), Collections.emptyMap());
+
+        assertNotNull(result);
+
+        // native TS enum, not a class
+        assertTrue(result, result.contains("enum EnumDeclarationTest$Color {"));
+        assertFalse(result, result.contains("class "));
+
+        // each constant maps to its own name as a string
+        assertTrue(result, result.contains("RED = \"RED\""));
+        assertTrue(result, result.contains("GREEN = \"GREEN\""));
+        assertTrue(result, result.contains("BLUE = \"BLUE\""));
+
+        // wrapped in its package namespace
+        assertTrue(result, result.contains("declare namespace org.bsc.java2typescript"));
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/Issue7Test.java
+++ b/core/src/test/java/org/bsc/java2typescript/Issue7Test.java
@@ -77,7 +77,7 @@ public class Issue7Test extends AbstractConverterTest {
 									true) ;
 			
 			assertNotNull( result );
-			assertEquals( "<E>( reducer:java.util.List<java.util.Map$Entry<E, V>> ):void", result );
+			assertEquals( "<E>( reducer:java.util.List<java.util.Map$Entry<E, V>> | (java.util.Map$Entry<E, V>)[] ):void", result );
 		}
 
 		

--- a/core/src/test/java/org/bsc/java2typescript/MemberClassTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/MemberClassTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 /**
  * 
@@ -62,6 +63,37 @@ public class MemberClassTest extends AbstractConverterTest {
                 Optional.empty());
 
         assertEquals( "Set<Map$Entry<K, V>>", result );
+    }
+
+    // Nested test fixtures: the source (dotted) name of Inner is
+    // org.bsc.java2typescript.MemberClassTest.Outer.Middle.Inner
+    // while its binary name is ...MemberClassTest$Outer$Middle$Inner
+    static class Outer {
+        static class Middle {
+            static class Inner {}
+        }
+    }
+
+    private static Class<?> resolveMemberClass(String fqn) throws Exception {
+        final Method m = TSType.class.getDeclaredMethod("getMemberClassForName", String.class);
+        m.setAccessible(true);
+        return (Class<?>) m.invoke(TSType.of(Object.class), fqn);
+    }
+
+    @Test
+    public void testSingleLevelNestedResolution() throws Exception {
+        assertEquals(java.util.Map.Entry.class, resolveMemberClass("java.util.Map.Entry"));
+    }
+
+    @Test
+    public void testDeeplyNestedResolution() throws Exception {
+        final String fqn = "org.bsc.java2typescript.MemberClassTest.Outer.Middle.Inner";
+        assertEquals(Outer.Middle.Inner.class, resolveMemberClass(fqn));
+    }
+
+    @Test
+    public void testUnresolvableMemberClassThrows() {
+        assertThrows(Exception.class, () -> resolveMemberClass("org.bsc.does.not.Exist.Nested"));
     }
 
 }

--- a/core/src/test/java/org/bsc/java2typescript/ProcessorTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/ProcessorTest.java
@@ -145,7 +145,7 @@ public class ProcessorTest extends AbstractConverterTest {
                     true);
 
             assertNotNull(result);
-            assertEquals( "( intList:List<int|null> ):List<string>", result );
+            assertEquals( "( intList:List<int|null> | (int|null)[] ):List<string>", result );
         }
 
     }

--- a/core/src/test/java/org/bsc/java2typescript/PublicConstructorTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/PublicConstructorTest.java
@@ -1,0 +1,46 @@
+package org.bsc.java2typescript;
+
+import java.lang.reflect.Constructor;
+
+import org.bsc.java2typescript.Java2TSConverter.Compatibility;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Public constructors are rendered as TypeScript {@code constructor( ... )} declarations by
+ * {@link TSConverterContext#getConstructorDecl(Constructor)}.
+ */
+public class PublicConstructorTest extends AbstractConverterTest {
+
+    static class Bean {
+        public Bean() {}
+        public Bean(String name, int count) {}
+        public Bean(String... tags) {}
+    }
+
+    private TSConverterContext ctx() {
+        return TSConverterContext.of(TSType.of(Bean.class),
+                declaredTypeMap(),
+                Java2TSConverter.Options.of(Compatibility.NASHORN));
+    }
+
+    @Test
+    public void noArgConstructor() throws Exception {
+        final Constructor<?> c = Bean.class.getConstructor();
+        // empty parameter list renders as "(  )" to match the existing method-decl convention
+        assertEquals("constructor(  )", ctx().getConstructorDecl(c));
+    }
+
+    @Test
+    public void constructorWithParameters() throws Exception {
+        final Constructor<?> c = Bean.class.getConstructor(String.class, int.class);
+        assertEquals("constructor( name:string, count:int )", ctx().getConstructorDecl(c));
+    }
+
+    @Test
+    public void varArgsConstructor() throws Exception {
+        final Constructor<?> c = Bean.class.getConstructor(String[].class);
+        assertEquals("constructor( ...tags:string[] )", ctx().getConstructorDecl(c));
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/PublicFieldTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/PublicFieldTest.java
@@ -50,10 +50,4 @@ public class PublicFieldTest extends AbstractConverterTest {
     public void finalInstanceFieldIsReadonly() throws Exception {
         assertEquals("readonly name:string", fieldDecl(Bean.class, "name"));
     }
-
-    @Test
-    public void staticFieldOnInterfaceIsCommentedOut() throws Exception {
-        // 'static' is illegal on a TS interface member, so it must be commented out.
-        assertEquals("// static readonly BAR:string", fieldDecl(Iface.class, "BAR"));
-    }
 }

--- a/core/src/test/java/org/bsc/java2typescript/PublicFieldTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/PublicFieldTest.java
@@ -1,0 +1,59 @@
+package org.bsc.java2typescript;
+
+import java.lang.reflect.Field;
+
+import org.bsc.java2typescript.Java2TSConverter.Compatibility;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Public fields are rendered as TypeScript property declarations by
+ * {@link TSConverterContext#getFieldDecl(Field)}.
+ */
+public class PublicFieldTest extends AbstractConverterTest {
+
+    static class Bean {
+        public static final String FOO = "x";
+        public int count;
+        public final String name;
+
+        Bean() { this.name = ""; }
+    }
+
+    interface Iface {
+        String BAR = "y"; // implicitly public static final
+    }
+
+    private TSConverterContext ctxFor(Class<?> type) {
+        return TSConverterContext.of(TSType.of(type),
+                declaredTypeMap(),
+                Java2TSConverter.Options.of(Compatibility.NASHORN));
+    }
+
+    private String fieldDecl(Class<?> type, String fieldName) throws Exception {
+        final Field f = type.getField(fieldName);
+        return ctxFor(type).getFieldDecl(f);
+    }
+
+    @Test
+    public void staticFinalFieldIsStaticReadonly() throws Exception {
+        assertEquals("static readonly FOO:string", fieldDecl(Bean.class, "FOO"));
+    }
+
+    @Test
+    public void plainFieldIsNameAndType() throws Exception {
+        assertEquals("count:int", fieldDecl(Bean.class, "count"));
+    }
+
+    @Test
+    public void finalInstanceFieldIsReadonly() throws Exception {
+        assertEquals("readonly name:string", fieldDecl(Bean.class, "name"));
+    }
+
+    @Test
+    public void staticFieldOnInterfaceIsCommentedOut() throws Exception {
+        // 'static' is illegal on a TS interface member, so it must be commented out.
+        assertEquals("// static readonly BAR:string", fieldDecl(Iface.class, "BAR"));
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/ReservedKeywordTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/ReservedKeywordTest.java
@@ -1,0 +1,44 @@
+package org.bsc.java2typescript;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Parameters whose Java name collides with a TypeScript reserved keyword must be renamed,
+ * otherwise the generated declaration is not valid TypeScript.
+ *
+ * @see TSConverterStatic#getParameterName(Parameter)
+ */
+public class ReservedKeywordTest {
+
+    // 'type', 'string' and 'number' are TS reserved words but perfectly valid Java identifiers,
+    // so they survive to the reflection layer where getParameterName must rename them.
+    interface Sample {
+        void m(String type, int number, String string, String name);
+    }
+
+    private static Parameter param(int index) throws Exception {
+        final Method m = Sample.class.getMethod("m", String.class, int.class, String.class, String.class);
+        return m.getParameters()[index];
+    }
+
+    @Test
+    public void reservedKeywordParametersGetSuffixed() throws Exception {
+        // guard: this test is meaningless unless the module is compiled with -parameters
+        assertTrue("expected real parameter names (compile with -parameters)", param(0).isNamePresent());
+
+        assertEquals("type_p", TSConverterStatic.getParameterName(param(0)));
+        assertEquals("number_p", TSConverterStatic.getParameterName(param(1)));
+        assertEquals("string_p", TSConverterStatic.getParameterName(param(2)));
+    }
+
+    @Test
+    public void nonReservedParameterKeptAsIs() throws Exception {
+        assertEquals("name", TSConverterStatic.getParameterName(param(3)));
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/StaticDefinitionTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/StaticDefinitionTest.java
@@ -1,0 +1,64 @@
+package org.bsc.java2typescript;
+
+import org.bsc.java2typescript.Java2TSConverter.Compatibility;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The {@code <out>-types.ts} runtime binding is slimmed to {@code typeof <class>} for classes and
+ * enums (whose full static side lives in the {@code .d.ts}), while interfaces keep an explicit
+ * {@code …Static} type because they have no {@code typeof} value form.
+ *
+ * @see org.bsc.java2typescript.transformer.TSJavaClass2StaticDefinitionTransformer
+ */
+public class StaticDefinitionTest extends AbstractConverterTest {
+
+    private Java2TSConverter converter;
+
+    @Before
+    public void initConverter() {
+        converter = Java2TSConverter.builder().compatibility(Compatibility.NASHORN).build();
+    }
+
+    @Test
+    public void classBindsViaTypeof() {
+
+        final String result = converter.javaClass2StaticDefinitionTransformer(
+                TSType.of(java.util.ArrayList.class).setExport(true),
+                declaredTypeMap(TSType.of(java.util.ArrayList.class)));
+
+        assertNotNull(result);
+        // slim binding, no duplicated static interface
+        assertTrue(result, result.contains("export const ArrayList: typeof java.util.ArrayList = Java.type(\"java.util.ArrayList\")"));
+        assertFalse(result, result.contains("ArrayListStatic"));
+    }
+
+    @Test
+    public void enumBindsViaTypeof() {
+
+        final String result = converter.javaClass2StaticDefinitionTransformer(
+                TSType.of(java.util.concurrent.TimeUnit.class).setExport(true),
+                declaredTypeMap(TSType.of(java.util.concurrent.TimeUnit.class)));
+
+        assertNotNull(result);
+        assertTrue(result, result.contains("export const TimeUnit: typeof java.util.concurrent.TimeUnit = Java.type(\"java.util.concurrent.TimeUnit\")"));
+        assertFalse(result, result.contains("TimeUnitStatic"));
+    }
+
+    @Test
+    public void interfaceKeepsStaticType() {
+
+        final String result = converter.javaClass2StaticDefinitionTransformer(
+                TSType.of(java.lang.Runnable.class).setExport(true),
+                declaredTypeMap(TSType.of(java.lang.Runnable.class)));
+
+        assertNotNull(result);
+        // interfaces have no `typeof` value form, so they keep the explicit static interface
+        assertTrue(result, result.contains("interface RunnableStatic"));
+        assertTrue(result, result.contains("export const Runnable: RunnableStatic = Java.type(\"java.lang.Runnable\")"));
+    }
+}

--- a/core/src/test/java/org/bsc/java2typescript/StaticMemberDeclarationTest.java
+++ b/core/src/test/java/org/bsc/java2typescript/StaticMemberDeclarationTest.java
@@ -1,0 +1,46 @@
+package org.bsc.java2typescript;
+
+import java.util.Collections;
+
+import org.bsc.java2typescript.Java2TSConverter.Compatibility;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Static members are emitted into the {@code .d.ts} class declaration (carrying the {@code static}
+ * keyword) even for exported types, so {@code typeof <class>} exposes the full static side and the
+ * {@code <out>-types.ts} binding can collapse to {@code typeof <class>}.
+ *
+ * @see org.bsc.java2typescript.transformer.TSJavaClass2DeclarationTransformer
+ */
+public class StaticMemberDeclarationTest extends AbstractConverterTest {
+
+    static class WithStatics {
+        public static String make() { return ""; }
+        public String instanceMethod() { return ""; }
+    }
+
+    private Java2TSConverter converter;
+
+    @Before
+    public void initConverter() {
+        converter = Java2TSConverter.builder().compatibility(Compatibility.NASHORN).build();
+    }
+
+    @Test
+    public void staticMethodEmittedForExportedType() {
+
+        final String result = converter.javaClass2DeclarationTransformer(0,
+                TSType.of(WithStatics.class).setExport(true),
+                Collections.emptyMap());
+
+        assertNotNull(result);
+        // static method is present (previously stripped for exported types) and keeps `static`
+        assertTrue(result, result.contains("static make"));
+        // instance method still present
+        assertTrue(result, result.contains("instanceMethod"));
+    }
+}

--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -217,16 +217,13 @@ public class TypescriptProcessor extends AbstractProcessorEx {
           .forEach(wT_append);
 
       // Type registry: maps each Java.type(...) string key to the concrete class value so that a
-      // call with a known key is strongly typed. Only classes/enums are eligible: a TypeScript
-      // interface has no value form and cannot be referenced with `typeof`, so Java interfaces are
-      // excluded and fall through to the generic `type(k:string):T` overload.
+      // call with a known key is strongly typed.
       wR_append.accept(String.format("/// <reference path=\"%s\"/>\n\n", definitionsFile));
       wR_append.accept(String.format("interface %s {\n", registryName));
 
       types.stream()
           .filter(tt -> !PREDEFINED_TYPES.contains(tt))
           .filter(TSType::supportNamespace)                 // skip aliased types (no namespace path)
-          .filter(tt -> !tt.getValue().isInterface())       // `typeof` needs a value
           .filter(tt -> tt.getValue().getPackage() != null) // skip the default (unnamed) package
           .map(tt -> String.format("  \"%s\": typeof %s;\n", tt.getValue().getName(), tt.getTypeName()))
           .distinct()

--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -209,6 +209,8 @@ public class TypescriptProcessor extends AbstractProcessorEx {
       // keeps its explicit flags (export, alias, ...) instead of being replaced by a scanned plain one.
       types.addAll(scanClasspath(processingContext));
 
+      types.removeIf(tt -> !isDeclarable(tt));
+
       final java.util.Map<String, TSType> declaredTypes =
           types.stream()
               .collect(Collectors.toMap(tt -> tt.getValue().getName(), tt -> tt));
@@ -254,11 +256,33 @@ public class TypescriptProcessor extends AbstractProcessorEx {
   }
 
   /**
-   * Enumerate the types to declare from the compiled class files given by {@code ts.scan}, if set.
+   * Whether a type can be introspected well enough to be declared.
    * <p>
-   * The resolved list is also written next to the declarations as {@code <outfile>-scan.txt}: what
-   * a scan included is otherwise invisible, and "why is this type missing?" is the first question
-   * asked of it.
+   * Types reaching here from {@code ts.scan} were already probed, but the ones named by
+   * {@link org.bsc.processor.annotation.Type} were not, and a single unresolvable reference in a
+   * method signature would otherwise abort generation for every type at once. Predefined types are
+   * exempt: they are built in and never rendered from reflection.
+   *
+   * @param type the candidate type
+   * @return     true when it can be declared
+   */
+  private boolean isDeclarable(TSType type) {
+
+    if (PREDEFINED_TYPES.contains(type)) {
+      return true;
+    }
+
+    try {
+      org.bsc.java2typescript.ClasspathScanner.checkIntrospectable(type.getValue());
+      return true;
+    } catch (Throwable t) {
+      warn("skipping [%s]: not introspectable (%s)", type.getValue().getName(), t);
+      return false;
+    }
+  }
+
+  /**
+   * Enumerate the types to declare from the compiled class files given by {@code ts.scan}, if set.
    *
    * @param processingContext the current processing context
    * @return                  the scanned types, empty when {@code ts.scan} is not set

--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -202,8 +202,11 @@ public class TypescriptProcessor extends AbstractProcessorEx {
           types.stream()
               .collect(Collectors.toMap(tt -> tt.getValue().getName(), tt -> tt));
 
+      // declaredTypes keeps reference-only types (declare == false) for name resolution and as
+      // `extends` targets, but they are declared in another generated file, so do not emit them.
       types.stream()
           .filter(tt -> !PREDEFINED_TYPES.contains(tt))
+          .filter(TSType::isDeclare)
           .map(tt -> converter.javaClass2DeclarationTransformer(0, tt, declaredTypes))
           .sorted()
           .forEach(wD_append);
@@ -212,6 +215,7 @@ public class TypescriptProcessor extends AbstractProcessorEx {
 
       types.stream()
           .filter(TSType::isExport)
+          .filter(TSType::isDeclare)
           .map(t -> converter.javaClass2StaticDefinitionTransformer(t, declaredTypes))
           .sorted()
           .forEach(wT_append);
@@ -223,6 +227,7 @@ public class TypescriptProcessor extends AbstractProcessorEx {
 
       types.stream()
           .filter(tt -> !PREDEFINED_TYPES.contains(tt))
+          .filter(TSType::isDeclare)                         // reference-only types belong to another file's registry
           .filter(TSType::supportNamespace)                 // skip aliased types (no namespace path)
           .filter(tt -> tt.getValue().getPackage() != null) // skip the default (unnamed) package
           .map(tt -> String.format("  \"%s\": typeof %s;\n", tt.getValue().getName(), tt.getTypeName()))

--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -1,5 +1,6 @@
 package org.bsc.processor;
 
+import org.bsc.java2typescript.ClasspathScanner;
 import org.bsc.java2typescript.TSNamespace;
 import org.bsc.java2typescript.TSType;
 import org.bsc.java2typescript.Java2TSConverter;
@@ -35,12 +36,18 @@ import static org.bsc.java2typescript.Java2TSConverter.PREDEFINED_TYPES;
  *     <li>{@code ts.outfile}: target file for typescript declarations</li>
  *     <li>{@code compatibility}: specify compatibility with a given script engine
  *     (NASHORN, RHINO, V8)</li>
+ *     <li>{@code ts.registry}: name of the generated type-registry interface</li>
+ *     <li>{@code ts.scan}: directories and/or jars to enumerate types from, in addition to the
+ *     ones listed in {@link Java2TS#declare()}. See {@link ClasspathScanner}</li>
+ *     <li>{@code ts.scan.include}, {@code ts.scan.exclude}: binary-name prefixes narrowing
+ *     {@code ts.scan}</li>
  * </ul>
  */
 //@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedAnnotationTypes("org.bsc.processor.annotation.*")
-@SupportedOptions({"ts.outfile", "compatibility", "ts.registry"})
+@SupportedOptions({"ts.outfile", "compatibility", "ts.registry",
+    ClasspathScanner.OPTION_SCAN, ClasspathScanner.OPTION_INCLUDE, ClasspathScanner.OPTION_EXCLUDE})
 @org.kohsuke.MetaInfServices(javax.annotation.processing.Processor.class)
 public class TypescriptProcessor extends AbstractProcessorEx {
 
@@ -198,6 +205,10 @@ public class TypescriptProcessor extends AbstractProcessorEx {
 
       namespaces.forEach(ns -> types.addAll(ns.types()));
 
+      // Added last: TSType equality is by class, so a type already declared through an annotation
+      // keeps its explicit flags (export, alias, ...) instead of being replaced by a scanned plain one.
+      types.addAll(scanClasspath(processingContext));
+
       final java.util.Map<String, TSType> declaredTypes =
           types.stream()
               .collect(Collectors.toMap(tt -> tt.getValue().getName(), tt -> tt));
@@ -240,6 +251,33 @@ public class TypescriptProcessor extends AbstractProcessorEx {
     } // end try-with-resources
 
     return true;
+  }
+
+  /**
+   * Enumerate the types to declare from the compiled class files given by {@code ts.scan}, if set.
+   * <p>
+   * The resolved list is also written next to the declarations as {@code <outfile>-scan.txt}: what
+   * a scan included is otherwise invisible, and "why is this type missing?" is the first question
+   * asked of it.
+   *
+   * @param processingContext the current processing context
+   * @return                  the scanned types, empty when {@code ts.scan} is not set
+   */
+  private Set<TSType> scanClasspath(final Context processingContext) throws IOException {
+
+    final Optional<ClasspathScanner> scanner =
+        ClasspathScanner.from(processingContext.getOptionMap());
+
+    if (!scanner.isPresent()) {
+      return Collections.emptySet();
+    }
+
+    final ClasspathScanner.Result result = scanner.get().scan();
+
+    info("SCAN: %d type(s) included, %d skipped (not loadable)",
+        result.types().size(), result.skipped().size());
+
+    return result.types();
   }
 
   /**

--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -40,7 +40,7 @@ import static org.bsc.java2typescript.Java2TSConverter.PREDEFINED_TYPES;
 //@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedAnnotationTypes("org.bsc.processor.annotation.*")
-@SupportedOptions({"ts.outfile", "compatibility"})
+@SupportedOptions({"ts.outfile", "compatibility", "ts.registry"})
 @org.kohsuke.MetaInfServices(javax.annotation.processing.Processor.class)
 public class TypescriptProcessor extends AbstractProcessorEx {
 
@@ -78,25 +78,52 @@ public class TypescriptProcessor extends AbstractProcessorEx {
   );
 
   /**
-   * Open a file for output.
+   * Create a writer for an output file under the {@code j2ts} source-output folder.
    *
-   * @param file     target file
-   * @param header   header file to prepend to the output
-   * @return         a writer for the output file
+   * @param file target file
+   * @return     a writer for the output file
    * @throws IOException if an I/O error occurs
    */
-  private java.io.Writer openFile(Path file, String header) throws IOException {
+  private java.io.Writer createWriter(Path file) throws IOException {
 
     final FileObject out = super.getSourceOutputFile(Paths.get("j2ts"), file);
 
     info("output file [%s]", out.getName());
 
-    final java.io.Writer w = out.openWriter();
+    return out.openWriter();
+  }
 
+  /**
+   * Read a classpath resource (a header template) as a UTF-8 string.
+   *
+   * @param header header resource name
+   * @return       the resource content
+   * @throws IOException if an I/O error occurs
+   */
+  private String readResource(String header) throws IOException {
     try (final java.io.InputStream is = getClass().getClassLoader().getResourceAsStream(header)) {
-      int c;
-      while ((c = is.read()) != -1) w.write(c);
+      return new String(is.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
     }
+  }
+
+  /**
+   * Open a file for output, prepending a header template whose placeholders have been substituted.
+   *
+   * @param file          target file
+   * @param header        header template resource to prepend to the output
+   * @param substitutions placeholder -&gt; replacement map applied to the header
+   * @return              a writer for the output file, positioned after the header
+   * @throws IOException if an I/O error occurs
+   */
+  private java.io.Writer openFile(Path file, String header, java.util.Map<String, String> substitutions) throws IOException {
+
+    final java.io.Writer w = createWriter(file);
+
+    String content = readResource(header);
+    for (final java.util.Map.Entry<String, String> e : substitutions.entrySet()) {
+      content = content.replace(e.getKey(), e.getValue());
+    }
+    w.write(content);
 
     return w;
   }
@@ -107,6 +134,16 @@ public class TypescriptProcessor extends AbstractProcessorEx {
 
     final String definitionsFile = targetDefinitionFile.concat(".d.ts");
     final String typesFile = targetDefinitionFile.concat("-types.ts");
+    final String registryFile = targetDefinitionFile.concat("-registry.d.ts");
+
+    // Name of the generated type-registry interface. Configurable so distinct projects can each
+    // produce their own registry (e.g. ZapApiTypeRegistry, ZapAddonApiTypeRegistry).
+    final String registryName =
+        processingContext.getOptionMap().getOrDefault("ts.registry", "JavaTypeRegistry");
+
+    // Substituted into the header templates (re-enables the typed Java.type overload).
+    final java.util.Map<String, String> headerSubstitutions =
+        Collections.singletonMap("{{REGISTRY_TYPE}}", registryName);
 
     final String foreignObjectPrototype =
             processingContext.getOptionMap()
@@ -123,8 +160,9 @@ public class TypescriptProcessor extends AbstractProcessorEx {
                                                     .build();
 
     try (
-        final java.io.Writer wD = openFile(Paths.get(definitionsFile), converter.isRhino() ? "headerD-rhino.ts" : "headerD.ts");
-        final java.io.Writer wT = openFile(Paths.get(typesFile), "headerT.ts");
+        final java.io.Writer wD = openFile(Paths.get(definitionsFile), converter.isRhino() ? "headerD-rhino.ts" : "headerD.ts", headerSubstitutions);
+        final java.io.Writer wT = openFile(Paths.get(typesFile), "headerT.ts", headerSubstitutions);
+        final java.io.Writer wR = createWriter(Paths.get(registryFile));
     ) {
 
       final Consumer<String> wD_append = s -> {
@@ -137,6 +175,13 @@ public class TypescriptProcessor extends AbstractProcessorEx {
       final Consumer<String> wT_append = s -> {
         try {
           wT.append(s);
+        } catch (IOException e) {
+          error("error adding [%s]", s);
+        }
+      };
+      final Consumer<String> wR_append = s -> {
+        try {
+          wR.append(s);
         } catch (IOException e) {
           error("error adding [%s]", s);
         }
@@ -170,6 +215,25 @@ public class TypescriptProcessor extends AbstractProcessorEx {
           .map(t -> converter.javaClass2StaticDefinitionTransformer(t, declaredTypes))
           .sorted()
           .forEach(wT_append);
+
+      // Type registry: maps each Java.type(...) string key to the concrete class value so that a
+      // call with a known key is strongly typed. Only classes/enums are eligible: a TypeScript
+      // interface has no value form and cannot be referenced with `typeof`, so Java interfaces are
+      // excluded and fall through to the generic `type(k:string):T` overload.
+      wR_append.accept(String.format("/// <reference path=\"%s\"/>\n\n", definitionsFile));
+      wR_append.accept(String.format("interface %s {\n", registryName));
+
+      types.stream()
+          .filter(tt -> !PREDEFINED_TYPES.contains(tt))
+          .filter(TSType::supportNamespace)                 // skip aliased types (no namespace path)
+          .filter(tt -> !tt.getValue().isInterface())       // `typeof` needs a value
+          .filter(tt -> tt.getValue().getPackage() != null) // skip the default (unnamed) package
+          .map(tt -> String.format("  \"%s\": typeof %s;\n", tt.getValue().getName(), tt.getTypeName()))
+          .distinct()
+          .sorted()
+          .forEach(wR_append);
+
+      wR_append.accept("}\n");
 
     } // end try-with-resources
 

--- a/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
+++ b/processor/src/main/java/org/bsc/processor/TypescriptProcessor.java
@@ -46,7 +46,7 @@ import static org.bsc.java2typescript.Java2TSConverter.PREDEFINED_TYPES;
 //@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedSourceVersion(SourceVersion.RELEASE_17)
 @SupportedAnnotationTypes("org.bsc.processor.annotation.*")
-@SupportedOptions({"ts.outfile", "compatibility", "ts.registry",
+@SupportedOptions({"ts.outfile", "compatibility", "ignoreDeprecated", "ts.registry",
     ClasspathScanner.OPTION_SCAN, ClasspathScanner.OPTION_INCLUDE, ClasspathScanner.OPTION_EXCLUDE})
 @org.kohsuke.MetaInfServices(javax.annotation.processing.Processor.class)
 public class TypescriptProcessor extends AbstractProcessorEx {
@@ -161,9 +161,13 @@ public class TypescriptProcessor extends AbstractProcessorEx {
             .getOrDefault("compatibility", "NASHORN") ;
     info("COMPATIBILITY WITH [%s]", compatibilityOption);
 
+    final boolean ignoreDeprecatedOption = !processingContext.getOptionMap()
+            .getOrDefault("ignoreDeprecated", "false").equals("false");
+
     final Java2TSConverter converter = Java2TSConverter.builder()
                                                     .compatibility( compatibilityOption  )
                                                     .foreignObjectPrototype( foreignObjectPrototype )
+                                                    .ignoreDeprecated(ignoreDeprecatedOption)
                                                     .build();
 
     try (
@@ -210,6 +214,15 @@ public class TypescriptProcessor extends AbstractProcessorEx {
       types.addAll(scanClasspath(processingContext));
 
       types.removeIf(tt -> !isDeclarable(tt));
+
+      // Removed from the type set, not merely left unrendered: everything downstream decides what
+      // to emit by looking types up here. A type dropped only at render time still gets an
+      // `extends` clause, a nested-type alias, a `-types.ts` binding and a registry entry, each
+      // pointing at a declaration that was never written.
+      if (ignoreDeprecatedOption) {
+        types.removeIf(tt -> !PREDEFINED_TYPES.contains(tt)
+            && tt.getValue().getAnnotation(Deprecated.class) != null);
+      }
 
       final java.util.Map<String, TSType> declaredTypes =
           types.stream()

--- a/processor/src/main/java/org/bsc/processor/annotation/Type.java
+++ b/processor/src/main/java/org/bsc/processor/annotation/Type.java
@@ -17,4 +17,8 @@ public @interface Type {
 	boolean export()		default false ;
 	String alias()			default "";
 	boolean functional()	default false;
+	// When false, the type is registered for name resolution / as an `extends` target only, and is
+	// NOT emitted as a declaration (nor added to the type registry). Use it to reference a type
+	// declared in another generated file (e.g. a base class emitted by a separate build).
+	boolean declare()		default true;
 }


### PR DESCRIPTION
Hi!

### foreword 

I wanted to generate types for the [Owasp Zap](https://github.com/zaproxy/zaproxy) pentest tool GraalJs API and it's [extensions](github.com/zaproxy/zap-extensions).
I found your project and it seemed to do perfectly what I wanted. As I had a Claude subscribtion, I used it to setup the project with Gradle... then fix a few bugs... then add features...
In the end it took me about a week to ship this massive overhaul.
I wholeheartly admit it's **mostly AI generated** as I'm very weak in Java and it's not a skill I want to improve: I want to do TS ^^'
(note that this pull request was 100% handwriten)
However tests still compile (very small change to 2 tests due to new features), and moreover I tested the Owasp Zap public API against it's example JS scripts I rewrote in TS.
You can check my [Zap example Typescript scripts](https://github.com/LucasParsy/Zaproxy_typescript_scripting_examples) repo, with the generated types, I have zero errors. 
(I have a few `any`s because I didn't generated types for javax or GraalJS does some funky stuff) 

### features

You could read the commits messages, I admit they are mostly AI-generated so verbose.
But I read and understood *mostly* all of it and to summarize what was added:

- fix: don't load static initializers when doing `Class.forName()` to prevent crash
- load nested classes / members
- add a suffix to parameters names having a reserved TS keyword (ex "in"). 
   - Was already implemented but only for the "function" keyword and not the 50~ others. 
- emit public fields in class/interfaces
- emit public constructors
- emit java enums as TS enums (GraalJs implementation)
- emit static members
- emit protected abstarct methods
- create a "types registry" for graalJS : associate a type to it's string name for GraalJS's `Java.type(typeName)`
    - so you can do `var myJavaType = Java.type('org.yourOrg.project.customClass')` without manually setting the TS type.
- `Java.Util.List<Type>` parameters can also be interpreted as Typescript `Type[]` arrays (GraalJS behavior)
- alias inner types: `Outer$InnerClass` can also be called as `Outer.InnerClass`
- add `class` member in class declarations
    - you can now do `myClassVar.class()`. I know there are other members we could add... but I don't need them!
- optimization: implement TS inheritance and extend classes
    - big commit but big optimization gains, Got a TS file going from 250K lines to 75K. x4~ size improv! 
    - But could be behind a feature flag as I think it tanks generation time.
- "declare type attribute" commit needed for my specific case where building the Zap extensions needed the base Zap types for the optimisation but without redeclaring them.
- create a processor option to scan all files/jar in a directory to automatically generate all types for the public classes of the project.  

### TODOs/"design" choices

##### Graal JS exclusive features without feature flags checks

I created my changes only for Graal JS in mind. I didn't tested anything for Rhino or Nashorn and didn't put features flags checks on my code, my bad... I can do the commit, but, better, if you can give me an example Rhino project, I can check the differences between the 2 projects and assess which new features are GraalJS only

##### AI verbose comments

I kept most of Claude's verbose comments. At least for review now I think it is useful, I don't know if most of it is useful for the long term.

##### GraalJS shenanigans

- `Java.Util.List<Type>` parameters can also be interpreted as Typescript `Type[]` arrays. For example I noted I could do `myArr.length()` and `myArr.length`.

- enums are treated as string enums, meaning you can do `myEnumVar == "VALUE"` (so `enum enType { VALUE = "VALUE"}`

- technically `string`, `List` or other types can be null in Java. So we should change all the methods parameters and return types to `type | null`. I don't want to generate a bloated and "unsafe" TS definition, so I chose to ignore this and manually edit my generated types on the methods that *really* return or expect `null` elements.

- `Java.super()` cannot be defined because it conflicts with TS "super".

- GraalJS `Java.extend()` allows modifying a class methods. It partially returns `any` because it would be impossible/very complex to give full typing to this.

##### upgrade version + changelog

I didn't do it, sorry, I let you do it if you want!
